### PR TITLE
Multi page

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -62,6 +62,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -70,6 +88,26 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.People"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/people/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "people"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -155,6 +193,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -222,6 +278,26 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.MultiActivity"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -307,6 +383,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -315,6 +409,26 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.ReturnedRisks"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/updates/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -402,6 +516,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -448,6 +580,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/projects/{id}/risks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "risks"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{id}/tasklists": {
             "get": {
                 "description": "Lists task lists based on project ID\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/7ee4827082194-get-all-task-lists-for-a-project for more parameter options.",
@@ -472,6 +624,24 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Page number",
                         "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
                         "in": "query"
                     }
                 ],
@@ -506,6 +676,101 @@ const docTemplate = `{
                         }
                     }
                 ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/tasklists/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasklists"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/tasks": {
+            "get": {
+                "description": "Lists all tasks based on project ID\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/6e3da2c04d779-get-all-tasks-on-a-given-project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Retrieves all tasks in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Enter project id",
+                        "name": "id",
+                        "in": "path"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Tasks"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/tasks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get number of pages and page length data",
                 "responses": {
                     "200": {
                         "description": "OK"
@@ -574,6 +839,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -620,6 +903,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/projects/{project_id}/timeentry/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "timeentry"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/v1/risks": {
             "get": {
                 "description": "List all risks across projects\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/64d22ab985a58-get-all-risks for more parameter options.",
@@ -639,6 +942,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -647,6 +968,26 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.ReturnedRisks"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/risks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "risks"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -854,6 +1195,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -862,6 +1221,26 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.Tasks"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/tasklists/{id}/tasks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasklists"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -885,6 +1264,24 @@ const docTemplate = `{
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -893,6 +1290,26 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.ReturnedTimeEntries"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/timeentries/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "timeentry"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -1198,6 +1615,9 @@ const docTemplate = `{
                 },
                 "prevCursor": {
                     "type": "string"
+                },
+                "totalCapacity": {
+                    "type": "integer"
                 }
             }
         },
@@ -1751,7 +2171,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "included": {},
-                "meta": {},
+                "meta": {
+                    "$ref": "#/definitions/models.Meta"
+                },
                 "risks": {
                     "type": "array",
                     "items": {
@@ -2048,7 +2470,7 @@ const docTemplate = `{
                 "STATUS": {
                     "type": "string"
                 },
-                "toDoItems": {
+                "todo-items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.ToDoItem"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -55,6 +55,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -63,6 +81,26 @@
                         "schema": {
                             "$ref": "#/definitions/models.People"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/people/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "people"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -148,6 +186,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -215,6 +271,26 @@
                         "schema": {
                             "$ref": "#/definitions/models.MultiActivity"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -300,6 +376,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -308,6 +402,26 @@
                         "schema": {
                             "$ref": "#/definitions/models.ReturnedRisks"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/updates/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -395,6 +509,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -441,6 +573,26 @@
                 }
             }
         },
+        "/api/v1/projects/{id}/risks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "risks"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{id}/tasklists": {
             "get": {
                 "description": "Lists task lists based on project ID\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/7ee4827082194-get-all-task-lists-for-a-project for more parameter options.",
@@ -465,6 +617,24 @@
                         "type": "string",
                         "description": "Page number",
                         "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
                         "in": "query"
                     }
                 ],
@@ -499,6 +669,101 @@
                         }
                     }
                 ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/tasklists/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasklists"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/tasks": {
+            "get": {
+                "description": "Lists all tasks based on project ID\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/6e3da2c04d779-get-all-tasks-on-a-given-project",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Retrieves all tasks in a project",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Enter project id",
+                        "name": "id",
+                        "in": "path"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Tasks"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/tasks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get number of pages and page length data",
                 "responses": {
                     "200": {
                         "description": "OK"
@@ -567,6 +832,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -613,6 +896,26 @@
                 }
             }
         },
+        "/api/v1/projects/{project_id}/timeentry/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "timeentry"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
         "/api/v1/risks": {
             "get": {
                 "description": "List all risks across projects\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/64d22ab985a58-get-all-risks for more parameter options.",
@@ -632,6 +935,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -640,6 +961,26 @@
                         "schema": {
                             "$ref": "#/definitions/models.ReturnedRisks"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/risks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "risks"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -847,6 +1188,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -855,6 +1214,26 @@
                         "schema": {
                             "$ref": "#/definitions/models.Tasks"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/tasklists/{id}/tasks/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tasklists"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -878,6 +1257,24 @@
                         "description": "Page number",
                         "name": "page",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Collates all pages",
+                        "name": "allPages",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "First page to collate",
+                        "name": "pageStart",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Last page to collate",
+                        "name": "pageEnd",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -886,6 +1283,26 @@
                         "schema": {
                             "$ref": "#/definitions/models.ReturnedTimeEntries"
                         }
+                    }
+                }
+            }
+        },
+        "/api/v1/timeentries/metadata": {
+            "get": {
+                "description": "Get page metadata for endpoint",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "timeentry"
+                ],
+                "summary": "Get number of pages and page length data",
+                "responses": {
+                    "200": {
+                        "description": "OK"
                     }
                 }
             }
@@ -1191,6 +1608,9 @@
                 },
                 "prevCursor": {
                     "type": "string"
+                },
+                "totalCapacity": {
+                    "type": "integer"
                 }
             }
         },
@@ -1744,7 +2164,9 @@
             "type": "object",
             "properties": {
                 "included": {},
-                "meta": {},
+                "meta": {
+                    "$ref": "#/definitions/models.Meta"
+                },
                 "risks": {
                     "type": "array",
                     "items": {
@@ -2041,7 +2463,7 @@
                 "STATUS": {
                     "type": "string"
                 },
-                "toDoItems": {
+                "todo-items": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/models.ToDoItem"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -156,6 +156,8 @@ definitions:
         $ref: '#/definitions/models.MetaPage'
       prevCursor:
         type: string
+      totalCapacity:
+        type: integer
     type: object
   models.MetaPage:
     properties:
@@ -523,7 +525,8 @@ definitions:
   models.ReturnedRisks:
     properties:
       included: {}
-      meta: {}
+      meta:
+        $ref: '#/definitions/models.Meta'
       risks:
         items:
           $ref: '#/definitions/models.Risks'
@@ -733,7 +736,7 @@ definitions:
     properties:
       STATUS:
         type: string
-      toDoItems:
+      todo-items:
         items:
           $ref: '#/definitions/models.ToDoItem'
         type: array
@@ -979,6 +982,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1029,6 +1044,19 @@ paths:
       summary: List projects for specified person
       tags:
       - people
+  /api/v1/people/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
+      tags:
+      - people
   /api/v1/projects:
     get:
       consumes:
@@ -1041,6 +1069,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1129,6 +1169,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1163,6 +1215,19 @@ paths:
       summary: Create a risk for a project
       tags:
       - risks
+  /api/v1/projects/{id}/risks/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
+      tags:
+      - risks
   /api/v1/projects/{id}/tasklists:
     get:
       consumes:
@@ -1179,6 +1244,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1209,6 +1286,70 @@ paths:
       summary: Create new tasklist
       tags:
       - tasklists
+  /api/v1/projects/{id}/tasklists/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
+      tags:
+      - tasklists
+  /api/v1/projects/{id}/tasks:
+    get:
+      consumes:
+      - application/json
+      description: |-
+        Lists all tasks based on project ID
+        Please refer to https://apidocs.teamwork.com/docs/teamwork/6e3da2c04d779-get-all-tasks-on-a-given-project
+      parameters:
+      - description: Enter project id
+        in: path
+        name: id
+        type: string
+      - description: Page number
+        in: query
+        name: page
+        type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Tasks'
+      summary: Retrieves all tasks in a project
+      tags:
+      - projects
+  /api/v1/projects/{id}/tasks/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
+      tags:
+      - projects
   /api/v1/projects/{id}/update:
     post:
       consumes:
@@ -1250,6 +1391,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1284,6 +1437,19 @@ paths:
       summary: Create a time entry for a project
       tags:
       - timeentry
+  /api/v1/projects/{project_id}/timeentry/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
+      tags:
+      - timeentry
   /api/v1/projects/activity:
     get:
       consumes:
@@ -1304,6 +1470,19 @@ paths:
           schema:
             $ref: '#/definitions/models.MultiActivity'
       summary: List latest activity across all projects
+      tags:
+      - projects
+  /api/v1/projects/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
       tags:
       - projects
   /api/v1/projects/update/{id}:
@@ -1362,6 +1541,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1370,6 +1561,19 @@ paths:
           schema:
             $ref: '#/definitions/models.ReturnedRisks'
       summary: Get all project updates
+      tags:
+      - projects
+  /api/v1/projects/updates/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
       tags:
       - projects
   /api/v1/risks:
@@ -1384,6 +1588,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1436,6 +1652,19 @@ paths:
         "200":
           description: OK
       summary: Update a project risk
+      tags:
+      - risks
+  /api/v1/risks/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
       tags:
       - risks
   /api/v1/specification/list:
@@ -1531,6 +1760,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1539,6 +1780,19 @@ paths:
           schema:
             $ref: '#/definitions/models.Tasks'
       summary: Retrieve a tasklist's tasks
+      tags:
+      - tasklists
+  /api/v1/tasklists/{id}/tasks/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
       tags:
       - tasklists
   /api/v1/timeentries:
@@ -1553,6 +1807,18 @@ paths:
         in: query
         name: page
         type: string
+      - description: Collates all pages
+        in: query
+        name: allPages
+        type: boolean
+      - description: First page to collate
+        in: query
+        name: pageStart
+        type: integer
+      - description: Last page to collate
+        in: query
+        name: pageEnd
+        type: integer
       produces:
       - application/json
       responses:
@@ -1607,6 +1873,19 @@ paths:
           schema:
             $ref: '#/definitions/models.CreatedTimeEntry'
       summary: Update a time entry
+      tags:
+      - timeentry
+  /api/v1/timeentries/metadata:
+    get:
+      consumes:
+      - application/json
+      description: Get page metadata for endpoint
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      summary: Get number of pages and page length data
       tags:
       - timeentry
 swagger: "2.0"

--- a/openapi.json
+++ b/openapi.json
@@ -47,6 +47,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -66,6 +90,20 @@
         ],
         "description": "Get a list of all people in the current user's company.",
         "summary": "Get all people from current user's company."
+      }
+    },
+    "/api/v1/people/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "people"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
       }
     },
     "/api/v1/people/{id}": {
@@ -142,6 +180,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -216,6 +278,20 @@
         "summary": "List latest activity across all projects"
       }
     },
+    "/api/v1/projects/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "projects"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
+      }
+    },
     "/api/v1/projects/update/{id}": {
       "delete": {
         "parameters": [
@@ -284,6 +360,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -303,6 +403,20 @@
         ],
         "description": "List all updates across projects that the logged-in user can access.\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/2e4f8bf140cab-get-all-project-updates for more parameter options.",
         "summary": "Get all project updates"
+      }
+    },
+    "/api/v1/projects/updates/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "projects"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
       }
     },
     "/api/v1/projects/{id}": {
@@ -379,6 +493,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -433,6 +571,20 @@
         "summary": "Create a risk for a project"
       }
     },
+    "/api/v1/projects/{id}/risks/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "risks"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
+      }
+    },
     "/api/v1/projects/{id}/tasklists": {
       "get": {
         "parameters": [
@@ -451,6 +603,30 @@
             "name": "page",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
             }
           }
         ],
@@ -493,6 +669,98 @@
           "description": "Enter tasklist properties"
         },
         "summary": "Create new tasklist"
+      }
+    },
+    "/api/v1/projects/{id}/tasklists/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "tasklists"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
+      }
+    },
+    "/api/v1/projects/{id}/tasks": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Enter project id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/models.Tasks"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "projects"
+        ],
+        "description": "Lists all tasks based on project ID\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/6e3da2c04d779-get-all-tasks-on-a-given-project",
+        "summary": "Retrieves all tasks in a project"
+      }
+    },
+    "/api/v1/projects/{id}/tasks/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "projects"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
       }
     },
     "/api/v1/projects/{id}/update": {
@@ -549,6 +817,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -603,6 +895,20 @@
         "summary": "Create a time entry for a project"
       }
     },
+    "/api/v1/projects/{project_id}/timeentry/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "timeentry"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
+      }
+    },
     "/api/v1/risks": {
       "get": {
         "parameters": [
@@ -612,6 +918,30 @@
             "name": "page",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
             }
           }
         ],
@@ -632,6 +962,20 @@
         ],
         "description": "List all risks across projects\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/64d22ab985a58-get-all-risks for more parameter options.",
         "summary": "Get all risks"
+      }
+    },
+    "/api/v1/risks/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "risks"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
       }
     },
     "/api/v1/risks/{id}": {
@@ -820,6 +1164,30 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -841,6 +1209,20 @@
         "summary": "Retrieve a tasklist's tasks"
       }
     },
+    "/api/v1/tasklists/{id}/tasks/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "tasklists"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
+      }
+    },
     "/api/v1/timeentries": {
       "get": {
         "parameters": [
@@ -850,6 +1232,30 @@
             "name": "page",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "description": "Collates all pages",
+            "in": "query",
+            "name": "allPages",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "First page to collate",
+            "in": "query",
+            "name": "pageStart",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Last page to collate",
+            "in": "query",
+            "name": "pageEnd",
+            "schema": {
+              "type": "integer"
             }
           }
         ],
@@ -870,6 +1276,20 @@
         ],
         "description": "List all time entries across projects and tasks\nPlease refer to https://apidocs.teamwork.com/docs/teamwork/4ea39d569915b-retrieve-all-time-entries-across-all-projects for more parameter options.",
         "summary": "Get all time entries"
+      }
+    },
+    "/api/v1/timeentries/metadata": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "tags": [
+          "timeentry"
+        ],
+        "description": "Get page metadata for endpoint",
+        "summary": "Get number of pages and page length data"
       }
     },
     "/api/v1/timeentries/{id}": {
@@ -1205,6 +1625,9 @@
           },
           "prevCursor": {
             "type": "string"
+          },
+          "totalCapacity": {
+            "type": "integer"
           }
         },
         "type": "object"
@@ -1758,7 +2181,9 @@
       "models.ReturnedRisks": {
         "properties": {
           "included": {},
-          "meta": {},
+          "meta": {
+            "$ref": "#/components/schemas/models.Meta"
+          },
           "risks": {
             "items": {
               "$ref": "#/components/schemas/models.Risks"
@@ -2055,7 +2480,7 @@
           "STATUS": {
             "type": "string"
           },
-          "toDoItems": {
+          "todo-items": {
             "items": {
               "$ref": "#/components/schemas/models.ToDoItem"
             },

--- a/pkg/app/helper.go
+++ b/pkg/app/helper.go
@@ -2,7 +2,10 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"net/url"
+	"strconv"
 )
 
 func respondWithError(w http.ResponseWriter, code int, message string) {
@@ -15,4 +18,47 @@ func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	w.Write(response)
+}
+
+func getPageRange(params url.Values, respHeaders http.Header, pageCount int) (int, int, error) {
+	var err error
+	pageStart := 1
+	pageEnd := 1
+	numPages := 1
+
+	if val, ok := params["pageStart"]; ok {
+		pageStart, err = strconv.Atoi(val[0])
+		pageEnd = pageStart
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	if val, ok := params["pageEnd"]; ok {
+		pageEnd, err = strconv.Atoi(val[0])
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	if pageCount != 0 {
+		numPages = pageCount
+	} else {
+		if respHeaders.Get("X-Pages") != "" {
+			numPages, err = strconv.Atoi(respHeaders.Get("X-Pages"))
+			if err != nil {
+				return 0, 0, err
+			}
+		}
+	}
+
+	if pageStart > numPages || pageEnd > numPages || pageStart < 1 {
+		return 0, 0, errors.New("invalid pageStart or pageEnd value")
+	}
+
+	if val, ok := params["allPages"]; ok && val[0] == "True" {
+		pageStart = 1
+		pageEnd = numPages
+	}
+
+	return pageStart, pageEnd, nil
 }

--- a/pkg/app/people_router.go
+++ b/pkg/app/people_router.go
@@ -37,6 +37,9 @@ func (a *App) getCurrentPerson(w http.ResponseWriter, r *http.Request) {
 // @Accept json
 // @Produce json
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.People
 // @Router /api/v1/people [get]
 func (a *App) getPeople(w http.ResponseWriter, r *http.Request) {

--- a/pkg/app/project_router.go
+++ b/pkg/app/project_router.go
@@ -18,6 +18,9 @@ import (
 // @Accept  json
 // @Produce  json
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.MultiProject
 // @Router /api/v1/projects [get]
 func (a *App) getAllProjects(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +190,9 @@ func (a *App) getLatestActivityAllProjects(w http.ResponseWriter, r *http.Reques
 // @Produce  json
 // @Param id path string false "Enter project id"
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.MultiTaskList
 // @Router /api/v1/projects/{id}/tasklists [get]
 func (a *App) getProjectTasklists(w http.ResponseWriter, r *http.Request) {
@@ -257,6 +263,9 @@ func (a *App) getProjectTasklistsMetadata(w http.ResponseWriter, r *http.Request
 // @Produce  json
 // @Param id path string false "Enter project id"
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.Tasks
 // @Router /api/v1/projects/{id}/tasks [get]
 func (a *App) getProjectTasks(w http.ResponseWriter, r *http.Request) {
@@ -399,6 +408,9 @@ func (a *App) createProjectUpdate(w http.ResponseWriter, r *http.Request) {
 // @Accept  json
 // @Produce  json
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.ReturnedRisks
 // @Router /api/v1/projects/updates [get]
 func (a *App) getAllProjectUpdates(w http.ResponseWriter, r *http.Request) {

--- a/pkg/app/risks_router.go
+++ b/pkg/app/risks_router.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"encoding/json"
+	"net/http"
+	"strconv"
+
 	"github.com/gorilla/mux"
 	"github.com/kosha/teamwork-connector/pkg/httpclient"
 	"github.com/kosha/teamwork-connector/pkg/models"
-	"net/http"
 )
 
 // createProjectRisk godoc
@@ -62,9 +64,45 @@ func (a *App) getAllRisks(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "*")
 
-	p := httpclient.GetAllRisks(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query())
+	var risks []*models.ReturnedRisks
+	var pageStart, pageEnd int
+	var err error
 
-	respondWithJSON(w, http.StatusOK, p)
+	_, data := httpclient.GetAllRisks(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), false)
+	pageStart, pageEnd, err = getPageRange(r.URL.Query(), nil, data.Metadata.Page.Count)
+
+	if err != nil {
+		a.Log.Errorf("Error getting page range", err)
+		respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	//get page data
+	params := r.URL.Query()
+	for i := pageStart; i <= pageEnd; i++ {
+		params["page"] = append(r.URL.Query()["page"], strconv.Itoa(i))
+		_, r := httpclient.GetAllRisks(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), params, false)
+		risks = append(risks, r)
+	}
+
+	respondWithJSON(w, http.StatusOK, risks)
+}
+
+// getAllRisksMetadata godoc
+// @Summary Get number of pages and page length data
+// @Description Get page metadata for endpoint
+// @Tags risks
+// @Accept  json
+// @Produce  json
+// @Success 200
+// @Router /api/v1/risks/metadata [get]
+func (a *App) getAllRisksMetadata(w http.ResponseWriter, r *http.Request) {
+
+	_, data := httpclient.GetAllRisks(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), false)
+	endpointMetadata := models.EndpointMetadata{
+		PageCount: data.Metadata.Page.Count,
+	}
+	respondWithJSON(w, http.StatusOK, endpointMetadata)
 }
 
 // getProjectRisks godoc
@@ -88,9 +126,47 @@ func (a *App) getProjectRisks(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["id"]
 
-	p := httpclient.GetProjectRisks(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query())
+	var risks []*models.ReturnedRisks
 
-	respondWithJSON(w, http.StatusOK, p)
+	respHeaders, _ := httpclient.GetProjectRisks(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), true)
+
+	//get page range data from headers
+	pageStart, pageEnd, err := getPageRange(r.URL.Query(), respHeaders, 0)
+	if err != nil {
+		a.Log.Errorf("Error getting page range", err)
+		respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	//get page data
+	params := r.URL.Query()
+	for i := pageStart; i <= pageEnd; i++ {
+		params["page"] = append(r.URL.Query()["page"], strconv.Itoa(i))
+		_, r := httpclient.GetProjectRisks(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), params, false)
+		risks = append(risks, r)
+	}
+
+	respondWithJSON(w, http.StatusOK, risks)
+
+}
+
+// getProjectRisksMetadata godoc
+// @Summary Get number of pages and page length data
+// @Description Get page metadata for endpoint
+// @Tags risks
+// @Accept  json
+// @Produce  json
+// @Success 200
+// @Router /api/v1/projects/{id}/risks/metadata [get]
+func (a *App) getProjectRisksMetadata(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	_, data := httpclient.GetProjectRisks(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), false)
+	endpointMetadata := models.EndpointMetadata{
+		PageCount: data.Metadata.Page.Count,
+	}
+	respondWithJSON(w, http.StatusOK, endpointMetadata)
 }
 
 // updateRisks godoc

--- a/pkg/app/risks_router.go
+++ b/pkg/app/risks_router.go
@@ -55,6 +55,9 @@ func (a *App) createProjectRisk(w http.ResponseWriter, r *http.Request) {
 // @Accept  json
 // @Produce  json
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.ReturnedRisks
 // @Router /api/v1/risks [get]
 func (a *App) getAllRisks(w http.ResponseWriter, r *http.Request) {
@@ -114,6 +117,9 @@ func (a *App) getAllRisksMetadata(w http.ResponseWriter, r *http.Request) {
 // @Produce  json
 // @Param id path string false "Enter project id"
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.ReturnedRisks
 // @Router /api/v1/projects/{id}/risks [get]
 func (a *App) getProjectRisks(w http.ResponseWriter, r *http.Request) {

--- a/pkg/app/routes.go
+++ b/pkg/app/routes.go
@@ -43,6 +43,7 @@ func (a *App) initializeRoutes() {
 	a.Router.HandleFunc(apiV1+"/projects/{id}/update", a.createProjectUpdate).Methods("POST", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/update/{id}", a.modifyProjectUpdate).Methods("PUT", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/update/{id}", a.deleteProjectUpdate).Methods("DELETE", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/projects/{id}/tasks", a.getProjectTasks).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}", a.getSingleProject).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects", a.getAllProjects).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}", a.deleteProject).Methods("DELETE", "OPTIONS")

--- a/pkg/app/routes.go
+++ b/pkg/app/routes.go
@@ -12,13 +12,16 @@ func (a *App) initializeRoutes() {
 	a.Router.HandleFunc(apiV1+"/specification/test", a.testConnectorSpecification).Methods("POST", "OPTIONS")
 
 	// tasklists
+	a.Router.HandleFunc(apiV1+"/projects/{id}/tasklists/metadata", a.getProjectTasklistsMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}/tasklists", a.getProjectTasklists).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}/tasklists", a.createTaskList).Methods("POST", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/tasklists/{id}/tasks/metadata", a.getTasksMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/tasklists/{id}/tasks", a.getTasks).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/tasklists/{id}", a.deleteTaskList).Methods("DELETE", "OPTIONS")
 
 	//people
 	a.Router.HandleFunc(apiV1+"/me", a.getCurrentPerson).Methods("GET", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/people/metadata", a.getPeopleMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/people/{id}/projects", a.getPersonsProjects).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/people/{id}", a.getPerson).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/people", a.getPeople).Methods("GET", "OPTIONS")
@@ -26,23 +29,30 @@ func (a *App) initializeRoutes() {
 	// time tracking
 	a.Router.HandleFunc(apiV1+"/timeentries/{id}", a.updateTimeEntry).Methods("PUT", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/timeentries/{id}", a.deleteTimeEntry).Methods("DELETE", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/timeentries/metadata", a.getAllTimeEntriesMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/timeentries", a.getAllTimeEntries).Methods("GET", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/projects/{project_id}/timeentry/metadata", a.getProjectTimeEntriesMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{project_id}/timeentry", a.getProjectTimeEntries).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{project_id}/timeentry", a.createProjectTimeEntry).Methods("POST", "OPTIONS")
 
 	// risks
+	a.Router.HandleFunc(apiV1+"/projects/{id}/risks/metadata", a.getProjectRisksMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}/risks", a.createProjectRisk).Methods("POST", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}/risks", a.getProjectRisks).Methods("GET", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/risks/metadata", a.getAllRisksMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/risks/{id}", a.updateRisks).Methods("PUT", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/risks/{id}", a.deleteRisks).Methods("DELETE", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/risks", a.getAllRisks).Methods("GET", "OPTIONS")
 
 	// projects
+	a.Router.HandleFunc(apiV1+"/projects/metadata", a.getAllProjectsMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/activity", a.getLatestActivityAllProjects).Methods("GET", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/projects/updates/metadata", a.getAllProjectUpdatesMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/updates", a.getAllProjectUpdates).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}/update", a.createProjectUpdate).Methods("POST", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/update/{id}", a.modifyProjectUpdate).Methods("PUT", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/update/{id}", a.deleteProjectUpdate).Methods("DELETE", "OPTIONS")
+	a.Router.HandleFunc(apiV1+"/projects/{id}/tasks/metadata", a.getProjectTasksMetadata).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}/tasks", a.getProjectTasks).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects/{id}", a.getSingleProject).Methods("GET", "OPTIONS")
 	a.Router.HandleFunc(apiV1+"/projects", a.getAllProjects).Methods("GET", "OPTIONS")

--- a/pkg/app/tasklist_router.go
+++ b/pkg/app/tasklist_router.go
@@ -47,6 +47,9 @@ func (a *App) deleteTaskList(w http.ResponseWriter, r *http.Request) {
 // @Produce  json
 // @Param id path string false "Enter tasklist id"
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.Tasks
 // @Router /api/v1/tasklists/{id}/tasks [get]
 func (a *App) getTasks(w http.ResponseWriter, r *http.Request) {

--- a/pkg/app/tasklist_router.go
+++ b/pkg/app/tasklist_router.go
@@ -1,9 +1,10 @@
 package app
 
 import (
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/kosha/teamwork-connector/pkg/httpclient"
-	"net/http"
 )
 
 // deleteTaskList godoc

--- a/pkg/app/time_tracking_router.go
+++ b/pkg/app/time_tracking_router.go
@@ -56,6 +56,9 @@ func (a *App) createProjectTimeEntry(w http.ResponseWriter, r *http.Request) {
 // @Accept  json
 // @Produce  json
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.ReturnedTimeEntries
 // @Router /api/v1/timeentries [get]
 func (a *App) getAllTimeEntries(w http.ResponseWriter, r *http.Request) {
@@ -121,6 +124,9 @@ func (a *App) getAllTimeEntriesMetadata(w http.ResponseWriter, r *http.Request) 
 // @Produce  json
 // @Param id path string false "Enter project id"
 // @Param page query string false "Page number"
+// @Param allPages query boolean false "Collates all pages"
+// @Param pageStart query integer false "First page to collate"
+// @Param pageEnd query integer false "Last page to collate"
 // @Success 200 {object} models.ReturnedTimeEntries
 // @Router /api/v1/projects/{project_id}/timeentry [get]
 func (a *App) getProjectTimeEntries(w http.ResponseWriter, r *http.Request) {

--- a/pkg/app/time_tracking_router.go
+++ b/pkg/app/time_tracking_router.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"encoding/json"
+	"net/http"
+	"strconv"
+
 	"github.com/gorilla/mux"
 	"github.com/kosha/teamwork-connector/pkg/httpclient"
 	"github.com/kosha/teamwork-connector/pkg/models"
-	"net/http"
 )
 
 // createProjectTimeEntry godoc
@@ -63,9 +65,51 @@ func (a *App) getAllTimeEntries(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "*")
 
-	p := httpclient.GetAllTimeEntries(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query())
+	var timeEntries []*models.ReturnedTimeEntries
 
-	respondWithJSON(w, http.StatusOK, p)
+	respHeaders, _ := httpclient.GetAllTimeEntries(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), true)
+
+	//get page range data from headers
+	pageStart, pageEnd, err := getPageRange(r.URL.Query(), respHeaders, 0)
+	if err != nil {
+		a.Log.Errorf("Error getting page range", err)
+		respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	//get page data
+	params := r.URL.Query()
+	for i := pageStart; i <= pageEnd; i++ {
+		params["page"] = append(r.URL.Query()["page"], strconv.Itoa(i))
+		_, t := httpclient.GetAllTimeEntries(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), params, false)
+		timeEntries = append(timeEntries, t)
+	}
+
+	respondWithJSON(w, http.StatusOK, timeEntries)
+}
+
+// getAllTimeEntriesMetadata godoc
+// @Summary Get number of pages and page length data
+// @Description Get page metadata for endpoint
+// @Tags timeentry
+// @Accept  json
+// @Produce  json
+// @Success 200
+// @Router /api/v1/timeentries/metadata [get]
+func (a *App) getAllTimeEntriesMetadata(w http.ResponseWriter, r *http.Request) {
+
+	respHeaders, _ := httpclient.GetAllTimeEntries(a.Cfg.GetTeamworkURL(), a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), true)
+	pageCount, err := strconv.Atoi(respHeaders.Get("X-Pages"))
+	if err != nil {
+		a.Log.Errorf("Error getting x-pages header", err)
+		respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	endpointMetadata := models.EndpointMetadata{
+		PageCount: pageCount,
+	}
+	respondWithJSON(w, http.StatusOK, endpointMetadata)
 }
 
 // getProjectTimeEntries godoc
@@ -89,9 +133,58 @@ func (a *App) getProjectTimeEntries(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id := vars["project_id"]
 
-	p := httpclient.GetProjectTimeEntries(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query())
+	var timeEntries []*models.ReturnedTimeEntries
 
-	respondWithJSON(w, http.StatusOK, p)
+	respHeaders, _ := httpclient.GetProjectTimeEntries(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), true)
+
+	//get page range data from headers
+	pageStart, pageEnd, err := getPageRange(r.URL.Query(), respHeaders, 0)
+	if err != nil {
+		a.Log.Errorf("Error getting page range", err)
+		respondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	//get page data
+	params := r.URL.Query()
+	for i := pageStart; i <= pageEnd; i++ {
+		params["page"] = append(r.URL.Query()["page"], strconv.Itoa(i))
+		_, t := httpclient.GetProjectTimeEntries(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), params, false)
+		timeEntries = append(timeEntries, t)
+	}
+
+	respondWithJSON(w, http.StatusOK, timeEntries)
+}
+
+// getProjectTimeEntriesMetadata godoc
+// @Summary Get number of pages and page length data
+// @Description Get page metadata for endpoint
+// @Tags timeentry
+// @Accept  json
+// @Produce  json
+// @Success 200
+// @Router /api/v1/projects/{project_id}/timeentry/metadata [get]
+func (a *App) getProjectTimeEntriesMetadata(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	pageCount := 1
+	var err error
+
+	respHeaders, _ := httpclient.GetProjectTimeEntries(a.Cfg.GetTeamworkURL(), id, a.Cfg.GetUsername(), a.Cfg.GetPassword(), r.URL.Query(), true)
+	if respHeaders.Get("X-Pages") != "" {
+		pageCount, err = strconv.Atoi(respHeaders.Get("X-Pages"))
+		if err != nil {
+			a.Log.Errorf("Error getting x-pages header", err)
+			respondWithError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	endpointMetadata := models.EndpointMetadata{
+		PageCount: pageCount,
+	}
+	respondWithJSON(w, http.StatusOK, endpointMetadata)
 }
 
 // updateTimeEntry godoc

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -68,21 +68,25 @@ func GetAccount(url string, username string, password string, params url.Values)
 	return account
 }
 
-func GetAllProjects(url string, username string, password string, params url.Values) *models.MultiProject {
+func GetAllProjects(url string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.MultiProject) {
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"projects/api/v3/projects.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"projects/api/v3/projects.json", nil)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	var project *models.MultiProject
+	var projects *models.MultiProject
 
 	res := makeHttpReq(username, password, req, params)
 
 	// Convert response body to target struct
-	err = json.Unmarshal(res, &project)
+	err = json.Unmarshal(res, &projects)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return project
+	return nil, projects
 }
 
 func GetSingleProject(url string, id string, username string, password string, params url.Values) *models.SingleProject {
@@ -103,12 +107,16 @@ func GetSingleProject(url string, id string, username string, password string, p
 	return project
 }
 
-func GetProjectTaskLists(url string, id string, username string, password string, params url.Values) *models.MultiTaskList {
+func GetProjectTaskLists(url string, id string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.MultiTaskList) {
+
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"projects/"+id+"/tasklists.json", params), nil
+	}
 
 	req, err := http.NewRequest("GET", url+"projects/"+id+"/tasklists.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var tasklists *models.MultiTaskList
 
@@ -116,9 +124,9 @@ func GetProjectTaskLists(url string, id string, username string, password string
 	// Convert response body to target struct
 	err = json.Unmarshal(res, &tasklists)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return tasklists
+	return nil, tasklists
 }
 
 func GetProjectTasks(url string, id string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.Tasks) {
@@ -144,11 +152,16 @@ func GetProjectTasks(url string, id string, username string, password string, pa
 	return nil, tasks
 }
 
-func GetTasks(url string, id string, username string, password string, params url.Values) *models.Tasks {
+func GetTasks(url string, id string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.Tasks) {
+
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"tasklists/"+id+"/tasks.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"tasklists/"+id+"/tasks.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var tasks *models.Tasks
 
@@ -156,9 +169,9 @@ func GetTasks(url string, id string, username string, password string, params ur
 	// Convert response body to target struct
 	err = json.Unmarshal(res, &tasks)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return tasks
+	return nil, tasks
 }
 
 func GetLatestActivityAllProjects(url string, username string, password string, params url.Values) *models.MultiActivity {
@@ -262,15 +275,19 @@ func GetCurrentPerson(url string, username string, password string, params url.V
 	return person
 }
 
-func GetPeople(url string, username string, password string, params url.Values) *models.People {
+func GetPeople(url string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.People) {
 
 	currentPerson := GetCurrentPerson(url, username, password, nil)
 	companyId := currentPerson.Person.CompanyId
 
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"companies/"+companyId+"/people.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"companies/"+companyId+"/people.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var people *models.People
 
@@ -278,16 +295,16 @@ func GetPeople(url string, username string, password string, params url.Values) 
 	// Convert response body to target struct
 	err = json.Unmarshal(res, &people)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return people
+	return nil, people
 }
 
 func GetPersonsProjects(url string, id string, username string, password string, params url.Values) *models.MultiProject {
 
 	customParams := make(map[string][]string)
 	customParams["fields[users]"] = append(customParams["fields[users]"], id)
-	projects := GetAllProjects(url, username, password, customParams)
+	_, projects := GetAllProjects(url, username, password, customParams, false)
 	return projects
 }
 
@@ -310,38 +327,48 @@ func CreateProjectTimeEntry(url string, project_id string, username string, pass
 	return createReply, nil
 }
 
-func GetAllTimeEntries(url string, username string, password string, params url.Values) *models.ReturnedTimeEntries {
+func GetAllTimeEntries(url string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.ReturnedTimeEntries) {
+
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"time_entries.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"time_entries.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	var tasks *models.ReturnedTimeEntries
+	var timeEntries *models.ReturnedTimeEntries
 
 	res := makeHttpReq(username, password, req, params)
 	// Convert response body to target struct
-	err = json.Unmarshal(res, &tasks)
+	err = json.Unmarshal(res, &timeEntries)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return tasks
+	return nil, timeEntries
 }
 
-func GetProjectTimeEntries(url string, project_id string, username string, password string, params url.Values) *models.ReturnedTimeEntries {
+func GetProjectTimeEntries(url string, project_id string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.ReturnedTimeEntries) {
+
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"projects/"+project_id+"/time_entries.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"projects/"+project_id+"/time_entries.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	var tasks *models.ReturnedTimeEntries
+	var timeEntries *models.ReturnedTimeEntries
 
 	res := makeHttpReq(username, password, req, params)
 	// Convert response body to target struct
-	err = json.Unmarshal(res, &tasks)
+	err = json.Unmarshal(res, &timeEntries)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return tasks
+	return nil, timeEntries
 }
 
 func UpdateTimeEntry(url string, id string, username string, password string, timeentry *models.CreateTimeEntry, params url.Values) (*models.CreatedTimeEntry, error) {
@@ -384,11 +411,15 @@ func CreateProjectUpdate(url string, id string, username string, password string
 	return string(makeHttpReq(username, password, req, params)), nil
 }
 
-func GetAllProjectUpdates(url string, username string, password string, params url.Values) *models.ProjectUpdateResponse {
+func GetAllProjectUpdates(url string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.ProjectUpdateResponse) {
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"projects/api/v3/projects/updates.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"projects/api/v3/projects/updates.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var updates *models.ProjectUpdateResponse
 
@@ -396,9 +427,9 @@ func GetAllProjectUpdates(url string, username string, password string, params u
 	// Convert response body to target struct
 	err = json.Unmarshal(res, &updates)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return updates
+	return nil, updates
 }
 
 func ModifyProjectUpdate(url string, id string, username string, password string, update *models.ProjectUpdate, params url.Values) (string, error) {
@@ -429,16 +460,23 @@ func CreateProjectRisk(url string, id string, username string, password string, 
 		return "", err
 	}
 	req, err := http.NewRequest("POST", url+"projects/"+id+"/risks.json", bytes.NewBuffer(jsonReq))
+	if err != nil {
+		return "", err
+	}
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	return string(makeHttpReq(username, password, req, params)), nil
 }
 
-func GetAllRisks(url string, username string, password string, params url.Values) *models.ReturnedRisks {
+func GetAllRisks(url string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.ReturnedRisks) {
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"projects/api/v3/risks.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"projects/api/v3/risks.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var risks *models.ReturnedRisks
 
@@ -446,16 +484,21 @@ func GetAllRisks(url string, username string, password string, params url.Values
 	// Convert response body to target struct
 	err = json.Unmarshal(res, &risks)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return risks
+	return nil, risks
 }
 
-func GetProjectRisks(url string, project_id string, username string, password string, params url.Values) *models.ReturnedRisks {
+func GetProjectRisks(url string, project_id string, username string, password string, params url.Values, getRespHeaders bool) (http.Header, *models.ReturnedRisks) {
+
+	if getRespHeaders {
+		return GetResponseHeaders(username, password, url+"projects/api/v3/projects/"+project_id+"/risks.json", params), nil
+	}
+
 	req, err := http.NewRequest("GET", url+"projects/api/v3/projects/"+project_id+"/risks.json", nil)
 
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	var tasks *models.ReturnedRisks
 
@@ -463,9 +506,9 @@ func GetProjectRisks(url string, project_id string, username string, password st
 	// Convert response body to target struct
 	err = json.Unmarshal(res, &tasks)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
-	return tasks
+	return nil, tasks
 }
 
 func UpdateRisks(url string, id string, username string, password string, risk *models.CreateRisk, params url.Values) (string, error) {

--- a/pkg/models/projects.go
+++ b/pkg/models/projects.go
@@ -147,11 +147,11 @@ type Update struct {
 	Health string `json:"health,omitempty"`
 }
 
-type ProjectUpdateResponse struct {
-	Included       interface{}        `json:"included,omitempty"`
-	Meta           interface{}        `json:"meta,omitempty"`
-	ProjectUpdates MultiProjectUpdate `json:"projectUpdates,omitempty"`
-}
+// type ProjectUpdateResponse struct {
+// 	Included       interface{}        `json:"included,omitempty"`
+// 	Metadata       interface{}        `json:"meta,omitempty"`
+// 	ProjectUpdates MultiProjectUpdate `json:"projectUpdates,omitempty"`
+// }
 
 type MultiProjectUpdate struct {
 	Color           string      `json:"color,omitempty"`
@@ -170,4 +170,468 @@ type MultiProjectUpdate struct {
 	Reactions       interface{} `json:"reactions,omitempty"`
 	Text            string      `json:"text,omitempty"`
 	UpdatedAt       string      `json:"updatedAt,omitempty"`
+}
+
+type ProjectUpdateResponse struct {
+	Included struct {
+		Projects struct {
+			Property1 struct {
+				ActivePages struct {
+					Billing      bool `json:"billing,omitempty"`
+					Board        bool `json:"board,omitempty"`
+					Comments     bool `json:"comments,omitempty"`
+					Files        bool `json:"files,omitempty"`
+					Finance      bool `json:"finance,omitempty"`
+					Forms        bool `json:"forms,omitempty"`
+					Gantt        bool `json:"gantt,omitempty"`
+					Links        bool `json:"links,omitempty"`
+					List         bool `json:"list,omitempty"`
+					Messages     bool `json:"messages,omitempty"`
+					Milestones   bool `json:"milestones,omitempty"`
+					Notebooks    bool `json:"notebooks,omitempty"`
+					RiskRegister bool `json:"riskRegister,omitempty"`
+					Table        bool `json:"table,omitempty"`
+					Tasks        bool `json:"tasks,omitempty"`
+					Time         bool `json:"time,omitempty"`
+				} `json:"activePages,omitempty"`
+				Announcement string `json:"announcement,omitempty"`
+				Category     struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"category,omitempty"`
+				CategoryID int `json:"categoryId,omitempty"`
+				Company    struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"company,omitempty"`
+				CompanyID           int    `json:"companyId,omitempty"`
+				CreatedAt           string `json:"createdAt,omitempty"`
+				CreatedBy           int    `json:"createdBy,omitempty"`
+				CustomFieldValueIds []int  `json:"customFieldValueIds,omitempty"`
+				CustomFieldValues   []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"customFieldValues,omitempty"`
+				CustomfieldValues []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"customfieldValues,omitempty"`
+				DefaultPrivacy           string `json:"defaultPrivacy,omitempty"`
+				Description              string `json:"description,omitempty"`
+				DirectFileUploadsEnabled bool   `json:"directFileUploadsEnabled,omitempty"`
+				EndAt                    string `json:"endAt,omitempty"`
+				EndDate                  string `json:"endDate,omitempty"`
+				FinancialBudget          struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"financialBudget,omitempty"`
+				FinancialBudgetID    int  `json:"financialBudgetId,omitempty"`
+				HarvestTimersEnabled bool `json:"harvestTimersEnabled,omitempty"`
+				ID                   int  `json:"id,omitempty"`
+				Integrations         struct {
+					OneDriveBusiness struct {
+						Account    string `json:"account,omitempty"`
+						Enabled    bool   `json:"enabled,omitempty"`
+						Folder     string `json:"folder,omitempty"`
+						FolderName string `json:"folderName,omitempty"`
+					} `json:"oneDriveBusiness,omitempty"`
+					Sharepoint struct {
+						Account    string `json:"account,omitempty"`
+						Enabled    bool   `json:"enabled,omitempty"`
+						Folder     string `json:"folder,omitempty"`
+						FolderName string `json:"folderName,omitempty"`
+					} `json:"sharepoint,omitempty"`
+					Xero struct {
+						BaseCurrency string `json:"baseCurrency,omitempty"`
+						Connected    bool   `json:"connected,omitempty"`
+						CountryCode  string `json:"countryCode,omitempty"`
+						Enabled      bool   `json:"enabled,omitempty"`
+						Organisation string `json:"organisation,omitempty"`
+					} `json:"xero,omitempty"`
+				} `json:"integrations,omitempty"`
+				IsBillable          bool   `json:"isBillable,omitempty"`
+				IsOnBoardingProject bool   `json:"isOnBoardingProject,omitempty"`
+				IsProjectAdmin      bool   `json:"isProjectAdmin,omitempty"`
+				IsSampleProject     bool   `json:"isSampleProject,omitempty"`
+				IsStarred           bool   `json:"isStarred,omitempty"`
+				LastWorkedOn        string `json:"lastWorkedOn,omitempty"`
+				LatestActivity      struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"latestActivity,omitempty"`
+				Logo                 string `json:"logo,omitempty"`
+				MinMaxAvailableDates struct {
+					DeadlinesFound     bool   `json:"deadlinesFound,omitempty"`
+					MaxEndDate         string `json:"maxEndDate,omitempty"`
+					MinStartDate       string `json:"minStartDate,omitempty"`
+					SuggestedEndDate   string `json:"suggestedEndDate,omitempty"`
+					SuggestedStartDate string `json:"suggestedStartDate,omitempty"`
+				} `json:"minMaxAvailableDates,omitempty"`
+				Name                        string `json:"name,omitempty"`
+				NotifyCommentIncludeCreator bool   `json:"notifyCommentIncludeCreator,omitempty"`
+				NotifyEveryone              bool   `json:"notifyEveryone,omitempty"`
+				NotifyTaskAssignee          bool   `json:"notifyTaskAssignee,omitempty"`
+				OverviewStartPage           string `json:"overviewStartPage,omitempty"`
+				OwnedBy                     int    `json:"ownedBy,omitempty"`
+				OwnerID                     int    `json:"ownerId,omitempty"`
+				PortfolioCards              []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"portfolioCards,omitempty"`
+				PrivacyEnabled bool `json:"privacyEnabled,omitempty"`
+				ProjectOwner   struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"projectOwner,omitempty"`
+				ProjectOwnerID      int    `json:"projectOwnerId,omitempty"`
+				ReplyByEmailEnabled bool   `json:"replyByEmailEnabled,omitempty"`
+				ShowAnnouncement    bool   `json:"showAnnouncement,omitempty"`
+				SkipWeekends        bool   `json:"skipWeekends,omitempty"`
+				StartAt             string `json:"startAt,omitempty"`
+				StartDate           string `json:"startDate,omitempty"`
+				StartPage           string `json:"startPage,omitempty"`
+				Status              string `json:"status,omitempty"`
+				SubStatus           string `json:"subStatus,omitempty"`
+				TagIds              []int  `json:"tagIds,omitempty"`
+				Tags                []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"tags,omitempty"`
+				TasksStartPage string `json:"tasksStartPage,omitempty"`
+				TimeBudget     struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"timeBudget,omitempty"`
+				TimeBudgetID int    `json:"timeBudgetId,omitempty"`
+				Type         string `json:"type,omitempty"`
+				Update       struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"update,omitempty"`
+				UpdateID  int    `json:"updateId,omitempty"`
+				UpdatedAt string `json:"updatedAt,omitempty"`
+				UpdatedBy int    `json:"updatedBy,omitempty"`
+				Users     []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"users,omitempty"`
+			} `json:"property1,omitempty"`
+			Property2 struct {
+				ActivePages struct {
+					Billing      bool `json:"billing,omitempty"`
+					Board        bool `json:"board,omitempty"`
+					Comments     bool `json:"comments,omitempty"`
+					Files        bool `json:"files,omitempty"`
+					Finance      bool `json:"finance,omitempty"`
+					Forms        bool `json:"forms,omitempty"`
+					Gantt        bool `json:"gantt,omitempty"`
+					Links        bool `json:"links,omitempty"`
+					List         bool `json:"list,omitempty"`
+					Messages     bool `json:"messages,omitempty"`
+					Milestones   bool `json:"milestones,omitempty"`
+					Notebooks    bool `json:"notebooks,omitempty"`
+					RiskRegister bool `json:"riskRegister,omitempty"`
+					Table        bool `json:"table,omitempty"`
+					Tasks        bool `json:"tasks,omitempty"`
+					Time         bool `json:"time,omitempty"`
+				} `json:"activePages,omitempty"`
+				Announcement string `json:"announcement,omitempty"`
+				Category     struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"category,omitempty"`
+				CategoryID int `json:"categoryId,omitempty"`
+				Company    struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"company,omitempty"`
+				CompanyID           int    `json:"companyId,omitempty"`
+				CreatedAt           string `json:"createdAt,omitempty"`
+				CreatedBy           int    `json:"createdBy,omitempty"`
+				CustomFieldValueIds []int  `json:"customFieldValueIds,omitempty"`
+				CustomFieldValues   []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"customFieldValues,omitempty"`
+				CustomfieldValues []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"customfieldValues,omitempty"`
+				DefaultPrivacy           string `json:"defaultPrivacy,omitempty"`
+				Description              string `json:"description,omitempty"`
+				DirectFileUploadsEnabled bool   `json:"directFileUploadsEnabled,omitempty"`
+				EndAt                    string `json:"endAt,omitempty"`
+				EndDate                  string `json:"endDate,omitempty"`
+				FinancialBudget          struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"financialBudget,omitempty"`
+				FinancialBudgetID    int  `json:"financialBudgetId,omitempty"`
+				HarvestTimersEnabled bool `json:"harvestTimersEnabled,omitempty"`
+				ID                   int  `json:"id,omitempty"`
+				Integrations         struct {
+					OneDriveBusiness struct {
+						Account    string `json:"account,omitempty"`
+						Enabled    bool   `json:"enabled,omitempty"`
+						Folder     string `json:"folder,omitempty"`
+						FolderName string `json:"folderName,omitempty"`
+					} `json:"oneDriveBusiness,omitempty"`
+					Sharepoint struct {
+						Account    string `json:"account,omitempty"`
+						Enabled    bool   `json:"enabled,omitempty"`
+						Folder     string `json:"folder,omitempty"`
+						FolderName string `json:"folderName,omitempty"`
+					} `json:"sharepoint,omitempty"`
+					Xero struct {
+						BaseCurrency string `json:"baseCurrency,omitempty"`
+						Connected    bool   `json:"connected,omitempty"`
+						CountryCode  string `json:"countryCode,omitempty"`
+						Enabled      bool   `json:"enabled,omitempty"`
+						Organisation string `json:"organisation,omitempty"`
+					} `json:"xero,omitempty"`
+				} `json:"integrations,omitempty"`
+				IsBillable          bool   `json:"isBillable,omitempty"`
+				IsOnBoardingProject bool   `json:"isOnBoardingProject,omitempty"`
+				IsProjectAdmin      bool   `json:"isProjectAdmin,omitempty"`
+				IsSampleProject     bool   `json:"isSampleProject,omitempty"`
+				IsStarred           bool   `json:"isStarred,omitempty"`
+				LastWorkedOn        string `json:"lastWorkedOn,omitempty"`
+				LatestActivity      struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"latestActivity,omitempty"`
+				Logo                 string `json:"logo,omitempty"`
+				MinMaxAvailableDates struct {
+					DeadlinesFound     bool   `json:"deadlinesFound,omitempty"`
+					MaxEndDate         string `json:"maxEndDate,omitempty"`
+					MinStartDate       string `json:"minStartDate,omitempty"`
+					SuggestedEndDate   string `json:"suggestedEndDate,omitempty"`
+					SuggestedStartDate string `json:"suggestedStartDate,omitempty"`
+				} `json:"minMaxAvailableDates,omitempty"`
+				Name                        string `json:"name,omitempty"`
+				NotifyCommentIncludeCreator bool   `json:"notifyCommentIncludeCreator,omitempty"`
+				NotifyEveryone              bool   `json:"notifyEveryone,omitempty"`
+				NotifyTaskAssignee          bool   `json:"notifyTaskAssignee,omitempty"`
+				OverviewStartPage           string `json:"overviewStartPage,omitempty"`
+				OwnedBy                     int    `json:"ownedBy,omitempty"`
+				OwnerID                     int    `json:"ownerId,omitempty"`
+				PortfolioCards              []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"portfolioCards,omitempty"`
+				PrivacyEnabled bool `json:"privacyEnabled,omitempty"`
+				ProjectOwner   struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"projectOwner,omitempty"`
+				ProjectOwnerID      int    `json:"projectOwnerId,omitempty"`
+				ReplyByEmailEnabled bool   `json:"replyByEmailEnabled,omitempty"`
+				ShowAnnouncement    bool   `json:"showAnnouncement,omitempty"`
+				SkipWeekends        bool   `json:"skipWeekends,omitempty"`
+				StartAt             string `json:"startAt,omitempty"`
+				StartDate           string `json:"startDate,omitempty"`
+				StartPage           string `json:"startPage,omitempty"`
+				Status              string `json:"status,omitempty"`
+				SubStatus           string `json:"subStatus,omitempty"`
+				TagIds              []int  `json:"tagIds,omitempty"`
+				Tags                []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"tags,omitempty"`
+				TasksStartPage string `json:"tasksStartPage,omitempty"`
+				TimeBudget     struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"timeBudget,omitempty"`
+				TimeBudgetID int    `json:"timeBudgetId,omitempty"`
+				Type         string `json:"type,omitempty"`
+				Update       struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"update,omitempty"`
+				UpdateID  int    `json:"updateId,omitempty"`
+				UpdatedAt string `json:"updatedAt,omitempty"`
+				UpdatedBy int    `json:"updatedBy,omitempty"`
+				Users     []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"users,omitempty"`
+			} `json:"property2,omitempty"`
+		} `json:"projects,omitempty"`
+		Users struct {
+			Property1 struct {
+				AvatarURL      string `json:"avatarUrl,omitempty"`
+				CanAddProjects bool   `json:"canAddProjects,omitempty"`
+				Company        struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"company,omitempty"`
+				CompanyID        int    `json:"companyId,omitempty"`
+				CompanyRoleID    int    `json:"companyRoleId,omitempty"`
+				Deleted          bool   `json:"deleted,omitempty"`
+				Email            string `json:"email,omitempty"`
+				FirstName        string `json:"firstName,omitempty"`
+				ID               int    `json:"id,omitempty"`
+				IsAdmin          bool   `json:"isAdmin,omitempty"`
+				IsClientUser     bool   `json:"isClientUser,omitempty"`
+				IsServiceAccount bool   `json:"isServiceAccount,omitempty"`
+				LastName         string `json:"lastName,omitempty"`
+				LengthOfDay      int    `json:"lengthOfDay,omitempty"`
+				Teams            []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"teams,omitempty"`
+				Title       string `json:"title,omitempty"`
+				Type        string `json:"type,omitempty"`
+				UserCost    int    `json:"userCost,omitempty"`
+				UserRate    int    `json:"userRate,omitempty"`
+				WorkingHour struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"workingHour,omitempty"`
+				WorkingHoursID int `json:"workingHoursId,omitempty"`
+			} `json:"property1,omitempty"`
+			Property2 struct {
+				AvatarURL      string `json:"avatarUrl,omitempty"`
+				CanAddProjects bool   `json:"canAddProjects,omitempty"`
+				Company        struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"company,omitempty"`
+				CompanyID        int    `json:"companyId,omitempty"`
+				CompanyRoleID    int    `json:"companyRoleId,omitempty"`
+				Deleted          bool   `json:"deleted,omitempty"`
+				Email            string `json:"email,omitempty"`
+				FirstName        string `json:"firstName,omitempty"`
+				ID               int    `json:"id,omitempty"`
+				IsAdmin          bool   `json:"isAdmin,omitempty"`
+				IsClientUser     bool   `json:"isClientUser,omitempty"`
+				IsServiceAccount bool   `json:"isServiceAccount,omitempty"`
+				LastName         string `json:"lastName,omitempty"`
+				LengthOfDay      int    `json:"lengthOfDay,omitempty"`
+				Teams            []struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"teams,omitempty"`
+				Title       string `json:"title,omitempty"`
+				Type        string `json:"type,omitempty"`
+				UserCost    int    `json:"userCost,omitempty"`
+				UserRate    int    `json:"userRate,omitempty"`
+				WorkingHour struct {
+					ID   int `json:"id,omitempty"`
+					Meta struct {
+					} `json:"meta,omitempty"`
+					Type string `json:"type,omitempty"`
+				} `json:"workingHour,omitempty"`
+				WorkingHoursID int `json:"workingHoursId,omitempty"`
+			} `json:"property2,omitempty"`
+		} `json:"users,omitempty"`
+	} `json:"included,omitempty"`
+	Metadata struct {
+		Limit      int    `json:"limit,omitempty"`
+		NextCursor string `json:"nextCursor,omitempty"`
+		Page       struct {
+			Count      int  `json:"count,omitempty"`
+			HasMore    bool `json:"hasMore,omitempty"`
+			PageOffset int  `json:"pageOffset,omitempty"`
+			PageSize   int  `json:"pageSize,omitempty"`
+		} `json:"page,omitempty"`
+		PrevCursor    string `json:"prevCursor,omitempty"`
+		TotalCapacity int    `json:"totalCapacity,omitempty"`
+	} `json:"meta,omitempty"`
+	ProjectUpdates []struct {
+		Color           string `json:"color,omitempty"`
+		CreatedAt       string `json:"createdAt,omitempty"`
+		CreatedBy       int    `json:"createdBy,omitempty"`
+		Deleted         bool   `json:"deleted,omitempty"`
+		DeletedAt       string `json:"deletedAt,omitempty"`
+		DeletedBy       int    `json:"deletedBy,omitempty"`
+		Health          int    `json:"health,omitempty"`
+		HealthLabel     string `json:"healthLabel,omitempty"`
+		ID              int    `json:"id,omitempty"`
+		LikeFromUserIDs []int  `json:"likeFromUserIDs,omitempty"`
+		LikeFromUsers   []struct {
+			ID   int `json:"id,omitempty"`
+			Meta struct {
+			} `json:"meta,omitempty"`
+			Type string `json:"type,omitempty"`
+		} `json:"likeFromUsers,omitempty"`
+		Project struct {
+			ID   int `json:"id,omitempty"`
+			Meta struct {
+			} `json:"meta,omitempty"`
+			Type string `json:"type,omitempty"`
+		} `json:"project,omitempty"`
+		ProjectID int `json:"projectId,omitempty"`
+		Reactions struct {
+			Counts struct {
+				Dislike int `json:"dislike,omitempty"`
+				Frown   int `json:"frown,omitempty"`
+				Heart   int `json:"heart,omitempty"`
+				Joy     int `json:"joy,omitempty"`
+				Like    int `json:"like,omitempty"`
+			} `json:"counts,omitempty"`
+			Mine []string `json:"mine,omitempty"`
+		} `json:"reactions,omitempty"`
+		Text      string `json:"text,omitempty"`
+		UpdatedAt string `json:"updatedAt,omitempty"`
+	} `json:"projectUpdates,omitempty"`
 }

--- a/pkg/models/risks.go
+++ b/pkg/models/risks.go
@@ -17,7 +17,7 @@ type Risk struct {
 
 type ReturnedRisks struct {
 	Included interface{} `json:"included,omitempty"`
-	Meta     interface{} `json:"meta,omitempty"`
+	Metadata Meta        `json:"meta,omitempty"`
 	Risks    []Risks     `json:"risks,omitempty"`
 }
 

--- a/pkg/models/shared.go
+++ b/pkg/models/shared.go
@@ -7,10 +7,11 @@ type Relationship struct {
 }
 
 type Meta struct {
-	Limit      int      `json:"limit,omitempty"`
-	NextCursor string   `json:"nextCursor,omitempty"`
-	Page       MetaPage `json:"page,omitempty"`
-	PrevCursor string   `json:"prevCursor,omitempty"`
+	Limit         int      `json:"limit,omitempty"`
+	NextCursor    string   `json:"nextCursor,omitempty"`
+	Page          MetaPage `json:"page,omitempty"`
+	PrevCursor    string   `json:"prevCursor,omitempty"`
+	TotalCapacity int      `json:"totalCapacity,omitempty"`
 }
 
 type MetaPage struct {
@@ -63,4 +64,8 @@ type Specification struct {
 	Username   string `json:"username,omitempty"`
 	Password   string `json:"password,omitempty"`
 	DomainName string `json:"domain_name,omitempty"`
+}
+
+type EndpointMetadata struct {
+	PageCount int
 }

--- a/pkg/models/tasklists.go
+++ b/pkg/models/tasklists.go
@@ -32,8 +32,8 @@ type NewTaskList struct {
 }
 
 type Tasks struct {
-	Status    string `json:"STATUS,omitempty"`
-	ToDoItems []ToDoItem
+	Status    string     `json:"STATUS,omitempty"`
+	ToDoItems []ToDoItem `json:"todo-items,omitempty"`
 }
 
 type ToDoList struct {


### PR DESCRIPTION
This change allows a user to set three different flags in mass pull endpoints that require paging. The three different flags are:
pageStart: start of page range (without a pageEnd specified, this is the only page pulled)
pageEnd: end of page range
allPages: grab all pages (this takes precedence above the other two)